### PR TITLE
modified requirements.txt

### DIFF
--- a/ProdirectScraper/requirements.txt
+++ b/ProdirectScraper/requirements.txt
@@ -1,5 +1,5 @@
 Twisted==14.0
 lxml==3.4
-pyOpenSSL==0.14
+pyOpenSSL==17.3.0
 Scrapy==1.4.0
 Jinja2==2.7

--- a/ProdirectScraper/requirements.txt
+++ b/ProdirectScraper/requirements.txt
@@ -3,3 +3,4 @@ lxml==3.4
 pyOpenSSL==17.3.0
 Scrapy==1.4.0
 Jinja2==2.7
+configparser==3.5.0


### PR DESCRIPTION
requirements.txt has following 2 problems:

1. version for pyOpenSSL is too old. It raises an exception which looks like:
**'module' object has no attribute 'SSL_ST_INIT'**
Updating to a newer version takes care of the issue. This issue is the same as mentioned by @mayela [here](https://github.com/ZoranPandovski/ProdirectScraper/issues/1). Similar issues were faced [here](https://github.com/MycroftAI/mycroft-core/issues/705).
2. configparser is not listed